### PR TITLE
Update to 1.4.1

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,27 +26,26 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9ec1c6ab22588242a47549f51a63dfc7c21fdf95a94820fc6e629ab060c38bd9",
-                "sha256:e1cef9a1a301866bcdee32ae0c699465eb2345f9a8e613a5835821430165ff6d"
+                "sha256:79450f92188a8b992b3d0b802028acadf448bc6fdde877c3262c9f94d74d1c7d",
+                "sha256:bf3153bf5d66be2bb2112edc94eb143c0cba3fb502c5591437bd1c54f57eb559"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.147"
+            "version": "==1.34.160"
         },
         "botocore": {
             "hashes": [
-                "sha256:2e8f000b77e4ca345146cb2edab6403769a517b564f627bb084ab335417f3dbe",
-                "sha256:be94a2f4874b1d1705cae2bd512c475047497379651678593acb6c61c50d91de"
+                "sha256:39bcf31318a062a8a9260bf7044131694ed18f019568d2eba0a22164fdca49bd",
+                "sha256:a5fd531c640fb2dc8b83f264efbb87a6e33b9c9f66ebbb1c61b42908f2786cac"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.147"
+            "version": "==1.34.160"
         },
         "certifi": {
             "hashes": [
                 "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
                 "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==2024.7.4"
         },

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ solder.py is even compatible with original solder's database, visit the install 
 
 ## Unfinished Features in dev
 
-
-
 # Installation/Updating
 
 solder.py is compatible with the original database and only adds columns to tables for the extra features we have, you can even dual run with both solder.py and original solder.
@@ -130,13 +128,13 @@ docker run --name solderpy --restart always -d -p 80:5000 thorfusion/solderpy
 
 #### Repo variables
 
-This is the public facing URL for your repository. If your repository location is already a URL, you can use the same value here. Include a trailing slash!
+This is the public facing URL for your repository. This is prefix url that technic launcher uses to download the mods. Include a trailing slash!
 
 ```bash
 -e SOLDER_MIRROR_URL=https://solder.example.com/mods/
 ```
 
-This is the location of your mod reposistory. This can be a URL (remote repo), or an absolute file location (local repo, much faster). When a remote repo is used, Solder will have to download the entire file to calculate the MD5 hash.
+This is the url solder.py uses to calculate md5 and filesize when rehashing or adding a mod manually. This is currently only url, so use localhost or local ip address if on the same network, else use same url as mirror url.
 
 ```bash
 -e SOLDER_REPO_LOCATION=https://solder.example.com/mods/

--- a/README.md
+++ b/README.md
@@ -188,6 +188,22 @@ If new user is enabled, you can enable this migration tool for technic solder da
 -e TECHNIC_MIGRATION=True
 ```
 
+#### API only mode
+
+solder.py will only run the api part of solder, allows it to run on read only permissions on a database, no login. good fit for public facing api only mode and another solder.py instance for local access only or similar for login and management
+
+```bash
+-e API_ONLY=True
+```
+
+#### Management only mode
+
+solder.py will run everything except api part of solder, quite rare usecase.
+
+```bash
+-e MANAGEMENT_ONLY=True
+```
+
 NOTE: The docker image does not and will not support https, therefore it is required to run an reverse proxy
 
 ## Dev Enviroment

--- a/app.py
+++ b/app.py
@@ -5,17 +5,19 @@ from alogin import alogin
 from asetup import asetup
 from asite import asite
 from flask import Flask, render_template
-from models.globals import debug, host, port
+from models.globals import debug, host, port, api_only, management_only
 
 __version__ = solderpy_version
 
 app: Flask = Flask(__name__)
-app.register_blueprint(api)
-app.register_blueprint(alogin)
-app.register_blueprint(asetup)
-app.register_blueprint(asite)
+if not management_only:
+    app.register_blueprint(api)
+if not api_only:
+    app.register_blueprint(alogin)
+    app.register_blueprint(asetup)
+    app.register_blueprint(asite)
 
-app.secret_key = secrets.token_hex()
+    app.secret_key = secrets.token_hex()
 
 @app.errorhandler(404)
 def page_not_found(e):

--- a/asetup.py
+++ b/asetup.py
@@ -6,6 +6,9 @@ from models.globals import migratetechnic, new_user
 
 asetup = Blueprint("asetup", __name__)
 
+if migratetechnic:
+    Database.create_session_table()
+
 @asetup.route("/setup", methods=["GET"])
 def setup():
     if not Database.is_setup():

--- a/asetup.py
+++ b/asetup.py
@@ -6,9 +6,6 @@ from models.globals import migratetechnic, new_user
 
 asetup = Blueprint("asetup", __name__)
 
-if migratetechnic:
-    Database.create_session_table()
-
 @asetup.route("/setup", methods=["GET"])
 def setup():
     if not Database.is_setup():

--- a/asite.py
+++ b/asite.py
@@ -120,18 +120,18 @@ def newmodversion(id):
 
         if request.form["rehash_md5"] != "":
             version = Modversion.get_by_id(request.form["rehash_id"])
-            version.update_hash(request.form["rehash_md5"], mirror_url + request.form["rehash_url"])
+            version.update_hash(request.form["rehash_md5"], repo_url + request.form["rehash_url"])
         else:
             version = Modversion.get_by_id(request.form["rehash_id"])
-            t = threading.Thread(target=version.rehash, args=(mirror_url + request.form["rehash_url"],))
+            t = threading.Thread(target=version.rehash, args=(repo_url + request.form["rehash_url"],))
             t.start()
     if "newmodvermanual_submit" in request.form:
-        filesie2 = Modversion.get_file_size(mirror_url + request.form["newmodvermanual_url"])
+        filesie2 = Modversion.get_file_size(repo_url + request.form["newmodvermanual_url"])
         if request.form["newmodvermanual_md5"] != "":
             Modversion.new(id, request.form["newmodvermanual_version"], request.form["newmodvermanual_mcversion"], request.form["newmodvermanual_md5"], filesie2, "0")
         else:
             # Todo Add filesize rehash and md5 hash, if fails do not add
-            Modversion.new(id, request.form["newmodvermanual_version"], request.form["newmodvermanual_mcversion"], "0", filesie2, "0", mirror_url + request.form["newmodvermanual_url"])
+            Modversion.new(id, request.form["newmodvermanual_version"], request.form["newmodvermanual_mcversion"], "0", filesie2, "0", repo_url + request.form["newmodvermanual_url"])
     return redirect(id)
 
 

--- a/asite.py
+++ b/asite.py
@@ -23,8 +23,7 @@ __version__ = solderpy_version
 
 asite = Blueprint("asite", __name__)
 
-if migratetechnic:
-    Database.create_session_table()
+Session.start_session_loop()
 
 ## Allowed extensions to be uploaded
 ALLOWED_EXTENSIONS = {'zip', 'jar'}

--- a/asite.py
+++ b/asite.py
@@ -23,7 +23,8 @@ __version__ = solderpy_version
 
 asite = Blueprint("asite", __name__)
 
-Session.start_session_loop()
+if migratetechnic:
+    Database.create_session_table()
 
 ## Allowed extensions to be uploaded
 ALLOWED_EXTENSIONS = {'zip', 'jar'}

--- a/models/build.py
+++ b/models/build.py
@@ -136,7 +136,12 @@ class Build:
     def get_modversions_minimal(self):
         conn = Database.get_connection()
         cursor = conn.cursor(dictionary=True)
-        cursor.execute("SELECT modversions.id, modversions.mod_id, modversions.version, modversions.mcversion, modversions.md5, modversions.created_at, modversions.updated_at, modversions.filesize, mods.name AS modname, build_modversion.optional FROM modversions INNER JOIN build_modversion ON modversions.id = build_modversion.modversion_id JOIN mods ON modversions.mod_id = mods.id WHERE build_modversion.build_id = %s", (self.id,))
+        cursor.execute(
+            """SELECT modversions.id, modversions.mod_id, modversions.version, modversions.mcversion, modversions.md5, modversions.created_at, modversions.updated_at, modversions.filesize, mods.name AS modname, build_modversion.optional 
+            FROM modversions 
+            INNER JOIN build_modversion ON modversions.id = build_modversion.modversion_id JOIN mods ON modversions.mod_id = mods.id 
+            WHERE build_modversion.build_id = %s AND build_modversion.optional = 0 AND mods.side IN ('CLIENT','BOTH')
+            """, (self.id,))
         modversions = cursor.fetchall()
         if modversions:
             versions = []

--- a/models/database.py
+++ b/models/database.py
@@ -88,11 +88,11 @@ class Database:
                         id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                         name VARCHAR(255) NOT NULL UNIQUE,
                         pretty_name VARCHAR(255) DEFAULT(''),
-                        description VARCHAR(255),
+                        description VARCHAR(255) DEFAULT(''),
                         author VARCHAR(255),
                         link VARCHAR(255),
-                        side enum('CLIENT', 'SERVER', 'BOTH'),
-                        modtype enum('MOD', 'LAUNCHER', 'RES', 'CONFIG', 'MCIL', 'NONE') DEFAULT 'NONE',
+                        side enum('CLIENT', 'SERVER', 'BOTH') DEFAULT 'BOTH',
+                        modtype enum('MOD', 'LAUNCHER', 'RES', 'CONFIG', 'MCIL', 'NONE') DEFAULT 'MOD',
                         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                         note TEXT
@@ -271,9 +271,9 @@ class Database:
             )
             cur.execute(
                 """ALTER TABLE mods
-                    ADD COLUMN side enum('CLIENT', 'SERVER', 'BOTH') AFTER link,
-                    ADD COLUMN modtype enum('MOD', 'LAUNCHER', 'RES', 'CONFIG', 'MCIL', 'NONE') DEFAULT 'NONE',
-                    ADD COLUMN note VARCHAR(255)
+                    ADD COLUMN side enum('CLIENT', 'SERVER', 'BOTH') DEFAULT 'BOTH',
+                    ADD COLUMN modtype enum('MOD', 'LAUNCHER', 'RES', 'CONFIG', 'MCIL', 'NONE') DEFAULT 'MOD',
+                    ADD COLUMN note VARCHAR(255) DEFAULT('')
                 """
             )
             cur.execute(

--- a/models/globals.py
+++ b/models/globals.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 
 ## Solderpy version
-solderpy_version = "1.4.0"
+solderpy_version = "1.4.1"
 
 load_dotenv(".env")
 

--- a/models/globals.py
+++ b/models/globals.py
@@ -17,6 +17,9 @@ port = os.getenv("APP_PORT")
 new_user = os.getenv("NEW_USER")
 migratetechnic = os.getenv("TECHNIC_MIGRATION")
 
+api_only = os.getenv("API_ONLY")
+management_only = os.getenv("MANAGEMENT_ONLY")
+
 debug = os.getenv("APP_DEBUG").lower() in ["true", "t", "1", "yes", "y"]
 
 mirror_url = os.getenv("SOLDER_MIRROR_URL")

--- a/templates/newmod.html
+++ b/templates/newmod.html
@@ -49,7 +49,7 @@
             <div class="mb-3 grid2">
                 <label>Select Type</label>
                 <div class="form-check">
-                    <input class="form-check-input" type="radio" name="type" id="type_MOD" value="MOD" required>
+                    <input class="form-check-input" type="radio" name="type" id="type_MOD" value="MOD" required checked>
                     <label class="form-check-label" for="type_MOD">
                         MOD
                     </label>
@@ -79,7 +79,7 @@
                     </label>
                 </div>
                 <div class="form-check">
-                    <input class="form-check-input" type="radio" name="type" id="type_NONE" value="NONE" required checked>
+                    <input class="form-check-input" type="radio" name="type" id="type_NONE" value="NONE" required>
                     <label class="form-check-label" for="type_NONE">
                         NONE
                     </label>


### PR DESCRIPTION
- Fixes mirror url being used in rehash or add mod manually, now uses repo url
- solder.py can now be run in only api or management mode aswell as both
- update dependencies
- on adding new mods, default type is now mod instead of none
- some smaller fixes for database when migration
	- during technicmigration, none in notes are now fixed by having default
	- mod side default is now both and not null
	- mod type default is now mod
	- same applies on database setup but frontend already have fixes so no issues there.
- solder api now respects mod side and optional tag

For people that migrated before 1.4.1 you need to run this mysql command in your database
```mysql
UPDATE mods SET side = 'BOTH' WHERE side IS NULL
```