### PR TITLE
Update to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY /static/ /app/static/
 COPY /templates/ /app/templates/
 COPY /api.py /app/
 COPY /app.py /app/
+COPY /alogin.py /app/
+COPY /asetup.py /app/
+COPY /asite.py /app/
 COPY /LICENSE.md /app/
 COPY /Pipfile /app/
 COPY /Pipfile.lock /app/

--- a/README.md
+++ b/README.md
@@ -206,6 +206,22 @@ solder.py will run everything except api part of solder, quite rare usecase.
 
 NOTE: The docker image does not and will not support https, therefore it is required to run an reverse proxy
 
+### docker container installed, setup on website
+
+Remember to set NEW_USER and TECHNIC_MIGRATION if using existing technic database, if clean install leave both.
+
+#### Step 1 Login screen
+
+When you have installed the container with the required envirables and created an mysql database and user that has access to said database, next step is to go to solder.py (http://example.com) where you will be redirected to login screen. by seeing this login screen, an successful connection to the database has been achieved. where you can find a table named sessions. go to (http://example.com/setup)
+
+#### Step 2 Setup screen
+
+Setup screen will take some time as when requesting this page, solder.py is creating the other tables in the database. when done the user will be presented with a email and password box with a setup button in the bottom, this is the administrator account you are creating. when setup is done, you will be redirected to login screen
+
+#### Step 3 Login screen again
+
+You will be redicted to log in screen, you can now login and be redirected to the index page, solder.py install is now complete. remember to disable NEW_USER and TECHNIC_MIGRATION as this allows the setup page to be up and random users to create accounts.
+
 ## Dev Enviroment
 
 ```bash

--- a/asite.py
+++ b/asite.py
@@ -46,8 +46,6 @@ def allowed_file(filename):
 def inject_menu():
     
     markedbuildid2 = Build.get_marked_build()
-    if markedbuildid2 == None:
-        markedbuildid2 = 0
     pinnedmodpacks = Modpack.get_by_pinned()
     
     return dict(markedbuildid2=markedbuildid2, solderversion=solderpy_version, pinnedmodpacks=pinnedmodpacks)

--- a/asite.py
+++ b/asite.py
@@ -500,7 +500,7 @@ def modpacklibrary_post():
         if "pinned_submit" in request.form:
             Modpack.update_checkbox(request.form["pinned_modid"], request.form["pinned_check"], "pinned", "modpacks")
 
-    return redirect(url_for('alogin.modpacklibrary'))
+    return redirect(url_for('asite.modpacklibrary'))
 
 
 @asite.route("/clients/<id>", methods=["GET", "POST"])

--- a/models/build.py
+++ b/models/build.py
@@ -128,10 +128,11 @@ class Build:
         conn = Database.get_connection()
         cur = conn.cursor(dictionary=True)
         cur.execute("SELECT id FROM builds WHERE marked = 1")
-        build_id = cur.fetchone()
-        if build_id:
+        try: 
+            build_id = cur.fetchone()["id"]
             return (build_id)
-        return 0
+        except:
+            return 0
 
     def get_modversions_minimal(self):
         conn = Database.get_connection()

--- a/models/build.py
+++ b/models/build.py
@@ -128,10 +128,10 @@ class Build:
         conn = Database.get_connection()
         cur = conn.cursor(dictionary=True)
         cur.execute("SELECT id FROM builds WHERE marked = 1")
-        build_id = cur.fetchone()["id"]
+        build_id = cur.fetchone()
         if build_id:
             return (build_id)
-        return None
+        return 0
 
     def get_modversions_minimal(self):
         conn = Database.get_connection()

--- a/models/database.py
+++ b/models/database.py
@@ -57,8 +57,6 @@ class Database:
                         name VARCHAR(255) NOT NULL UNIQUE,
                         slug VARCHAR(255) NOT NULL UNIQUE,
                         user_id INT NOT NULL,
-                        minecraft VARCHAR(255) NOT NULL DEFAULT(''),
-                        forge VARCHAR(255),
                         recommended VARCHAR(255),
                         latest VARCHAR(255),
                         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -76,6 +74,8 @@ class Database:
                         version VARCHAR(255) NOT NULL,
                         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        minecraft VARCHAR(255) NOT NULL DEFAULT(''),
+                        forge VARCHAR(255),
                         is_published TINYINT(1) DEFAULT(0),
                         private TINYINT(1) DEFAULT(0),
                         min_java VARCHAR(255),
@@ -264,8 +264,6 @@ class Database:
             cur.execute(
                 """ALTER TABLE modpacks
                     ADD COLUMN user_id INT NOT NULL AFTER slug,
-                    ADD COLUMN minecraft VARCHAR(255) NOT NULL DEFAULT(''),
-                    ADD COLUMN forge VARCHAR(255),
                     ADD COLUMN pinned TINYINT(1) NOT NULL DEFAULT(0)
                 """
             )
@@ -278,6 +276,8 @@ class Database:
             )
             cur.execute(
                 """ALTER TABLE builds
+                    ADD COLUMN minecraft VARCHAR(255) NOT NULL DEFAULT(''),
+                    ADD COLUMN forge VARCHAR(255),
                     ADD COLUMN marked TINYINT(1) NOT NULL DEFAULT(0)
                 """
             )

--- a/models/globals.py
+++ b/models/globals.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 
 ## Solderpy version
-solderpy_version = "1.4.1"
+solderpy_version = "1.4.2"
 
 load_dotenv(".env")
 

--- a/models/modversion.py
+++ b/models/modversion.py
@@ -29,7 +29,7 @@ class Modversion:
         cur.execute("SELECT LAST_INSERT_ID() AS id")
         id = cur.fetchone()["id"]
         conn.commit()
-        if markedbuild is "1":
+        if markedbuild == "1":
             Modversion.add_modversion_to_selected_build(id, mod_id, "0", "1", "0")
         if md5 == "0":
             version = Modversion.get_by_id(id)


### PR DESCRIPTION
- fixes docker container missing the blueprints and therefore broken
- fixes minecraft and forge columns being created in the wrong table, both migration and new setup has this issue, to fix, run migration tool, then manually delete the columns from modpacks table
-  fixes a return on modpacklibrary page
- a proper proper fix for the setup issue since 1.3.4